### PR TITLE
Removed #ateam channel

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -11,7 +11,6 @@
     "participate": {
         "home": "https://github.com/mozilla/moz-sql-parser",
         "docs": "https://github.com/mozilla/moz-sql-parser/docs",
-        "irc": "irc://irc.mozilla.org/#ateam",
         "irc-contacts": [
             "ekyle"
         ]


### PR DESCRIPTION
Removed #ateam channel from because it is no longer exist. (Reference: https://groups.google.com/forum/#!msg/mozilla.dev.platform/R8QQHTNEROw/7sQSv0GTEwAJ)